### PR TITLE
Include api-version

### DIFF
--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,6 +1,7 @@
 main: de.rexlnico.realtimeplugin.main.Main
 authors: [ rexlNico, fluse1367 ]
 version: 3.0
+api-version: 1.13
 name: RealTimePlugin
 website: https://rexlNico.de
 


### PR DESCRIPTION
This is such that Spigot doesn't think that this is a legacy plugin (which has been bugging me for quite some time)