### PR TITLE
Add api-version to plugin.yml

### DIFF
--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,6 +1,7 @@
 main: de.rexlnico.realtimeplugin.main.Main
 authors: [ rexlNico, fluse1367 ]
 version: 3.5
+api-version: 1.13
 name: RealTimePlugin
 website: https://rexlNico.de
 


### PR DESCRIPTION
Without the api-version, /plugins will print RealTimePlugins* in 1.13 and later versions. By setting the api-version to 1.13, it will be ignored in earlier versions and can still be used in 1.13 and above. (duplicate #2)

## Changes

### Before
![](https://user-images.githubusercontent.com/34268371/158071647-0d3f87ee-7e17-4e44-9858-ec16a8f790ae.png)

### After
![](https://user-images.githubusercontent.com/34268371/158071707-ac71e4bb-c3f4-44b9-b61d-bd320488876d.png)
